### PR TITLE
ref(offers): Refactor all offers endpoint from body to params

### DIFF
--- a/spring-boot-service/src/main/java/com/mimaja/job_finder_app/feature/offer/controller/OfferController.java
+++ b/spring-boot-service/src/main/java/com/mimaja/job_finder_app/feature/offer/controller/OfferController.java
@@ -47,9 +47,17 @@ public class OfferController {
 
     @GetMapping
     public ResponseDto<Page<OfferSummaryResponseDto>> getAllOffers(
-            @Valid @RequestBody OfferFilterRequestDto offerFilterRequestDto,
+            @RequestParam(required = false) LocalDateTime firstDate,
+            @RequestParam(required = false) LocalDateTime lastDate,
+            @RequestParam(required = false) Double minSalary,
+            @RequestParam(required = false) Double maxSalary,
+            @RequestParam(required = false) Set<UUID> categories,
+            @RequestParam(required = false) Set<UUID> tags,
             @PageableDefault(sort = "createdAt", size = 20, direction = Sort.Direction.DESC)
                     Pageable pageable) {
+        OfferFilterRequestDto offerFilterRequestDto =
+                new OfferFilterRequestDto(
+                        firstDate, lastDate, minSalary, maxSalary, categories, tags);
         return new ResponseDto<>(
                 SuccessCode.RESPONSE_SUCCESSFUL,
                 "Successfully fetched offers",

--- a/spring-boot-service/src/main/java/com/mimaja/job_finder_app/feature/offer/filterspecification/OfferFilterSpecification.java
+++ b/spring-boot-service/src/main/java/com/mimaja/job_finder_app/feature/offer/filterspecification/OfferFilterSpecification.java
@@ -12,10 +12,13 @@ import java.util.List;
 import org.springframework.data.jpa.domain.Specification;
 
 public class OfferFilterSpecification {
+    private OfferFilterSpecification() {}
+
     public static Specification<Offer> filter(OfferFilterRequestDto dto) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
 
+            assert query != null;
             query.distinct(true);
 
             if (dto.firstDate() != null) {


### PR DESCRIPTION
** BODY -> PARAMS

From now on GET `/offer` request takes query params instead of body for filtering offers